### PR TITLE
SEP-24 popup window closes immediately

### DIFF
--- a/src/routes/dashboard/transfers/+page.svelte
+++ b/src/routes/dashboard/transfers/+page.svelte
@@ -252,7 +252,9 @@ couple read-throughs to understand everything.
         // We listen for the callback `message` from the popup window
         window.addEventListener('message', async (event) => {
             console.log('here is the event i heard from the popup window', event)
-            popup?.close()
+            if (event.data.contains("test")) {
+                popup?.close()
+            }
 
             // Store the transfer in the browser's localStorage
             transfers.addTransfer({


### PR DESCRIPTION
This is a WIP.

Closes #9.

I added the if statement to check for the events, however I was going to do some testing on checking the different types of status messages and create the if statement properly. 

I got some issues while trying to search the SEP-24 popup window. I went to `dashboard/transfers`, but didn't see the title saying `SEP-24 Transfers` which is only shown once the `stellar.toml` is fetched (I understood this). Also, I'm not seeing any text besides the last paragraph which ends in line 330. 

I would appreciate some guidance on how to show the `SEP-24 Transfers` title to open the popup window, and get the possible messages. After doing my implentation, I would test it properly. Thank you!